### PR TITLE
Initial implementation of a shell in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+project(minixonsh C CXX)
+
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release
+        CACHE STRING "Build type (Debug, Release)" FORCE)
+endif ()
+if (NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+        CMAKE_BUILD_TYPE STREQUAL "Release"))
+    message("${CMAKE_BUILD_TYPE}")
+    message(FATAL_ERROR "CMAKE_BUILD_TYPE must be one of: Debug, Release (current value: '${CMAKE_BUILD_TYPE}')")
+endif ()
+
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17
+        CACHE STRING "C++ standard" FORCE)
+endif ()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+enable_testing()
+
+message("\n")
+message("Configuration results")
+message("---------------------")
+message("C compiler      : ${CMAKE_C_COMPILER}")
+message("C++ compiler    : ${CMAKE_CXX_COMPILER}")
+message("Build type: ${CMAKE_BUILD_TYPE}")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("C compiler flags      : ${CMAKE_C_FLAGS_DEBUG}")
+    message("C++ compiler flags    : ${CMAKE_CXX_FLAGS_DEBUG}")
+else ()
+    message("C compiler flags      : ${CMAKE_C_FLAGS_RELEASE}")
+    message("C++ compiler flags    : ${CMAKE_CXX_FLAGS_RELEASE}")
+endif ()
+message("Installation prefix: ${CMAKE_INSTALL_PREFIX}")
+
+add_executable(minixonsh src/main.cpp)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <sys/wait.h>
+
+#include <stdio.h>
+#include <unistd.h>
+
+int run_command(const std::vector<std::string> &args)
+{
+    char *cargs[args.size()+1];
+    for (size_t i=0; i < args.size(); i++) {
+        cargs[i] = const_cast<char*>(args[i].c_str());
+    }
+    cargs[args.size()] = nullptr;
+
+    pid_t pid = fork();
+    if (pid == 0)
+    {
+        // Child process
+        execv(cargs[0], &cargs[0]);
+        // Execv failed
+        throw std::runtime_error("execv() failed");
+    }
+    else if (pid < 0)
+    {
+        // Fork failed
+        throw std::runtime_error("fork() failed");
+    }
+
+    // Parent process
+    int child_status;
+    pid_t tpid;
+    do {
+        tpid = wait(&child_status);
+        if (tpid != pid) {
+            std::cout << "Process terminated:" << tpid << std::endl;
+        }
+    } while (tpid != pid);
+    return child_status;
+}
+
+int print_command(const std::vector<std::string> &args)
+{
+    std::cout << "+ ";
+    for (size_t i=0; i < args.size(); i++) {
+        std::cout << args[i];
+        if (i < args.size()-1) std::cout << " ";
+    }
+    std::cout << std::endl;
+}
+
+std::vector<std::string> readlines(const std::string filename)
+{
+    std::vector<std::string> lines;
+    std::fstream in;
+    in.open("test1.xsh");
+    std::string line;
+    std::getline(in, line);
+    while (in.rdstate() == std::ios_base::goodbit) {
+        lines.push_back(line);
+        std::getline(in, line);
+    }
+    return lines;
+}
+
+std::vector<std::string> split(const std::string str)
+{
+    std::vector<std::string> tokens;
+    std::stringstream ss(str);
+    std::string token;
+    while (std::getline(ss, token, ' ')) {
+        tokens.push_back(token);
+    };
+    return tokens;
+}
+
+int main(int argc, char **argv)
+{
+    std::vector<std::string> lines = readlines(argv[1]);
+
+    for (auto && line : lines) {
+        std::vector<std::string> args = split(line);
+        // TODO: search args[0] in $PATH instead:
+        args[0] = "/bin/" + args[0];
+        print_command(args);
+        int c = run_command(args);
+        if (c != 0) return c;
+    }
+
+    return 0;
+}

--- a/test1.xsh
+++ b/test1.xsh
@@ -1,0 +1,3 @@
+ls -l
+ls
+echo "OK"


### PR DESCRIPTION
Only tested on Linux. Here are the benchmarks on my machine executing the same script using Xonsh, Bash and Minixonsh.

Xonsh:
```
$ time xonsh test1.xsh 
total 88
-rw-r--r-- 1 certik certik 12541 Nov  6 15:44 CMakeCache.txt
drwxr-xr-x 5 certik certik  4096 Nov  6 15:44 CMakeFiles
-rw-r--r-- 1 certik certik  1254 Nov  4 12:43 CMakeLists.txt
-rw-r--r-- 1 certik certik   269 Nov  6 15:44 CTestTestfile.cmake
-rw-r--r-- 1 certik certik  1513 Nov  4 12:43 LICENSE
-rw-r--r-- 1 certik certik  5136 Nov  6 15:44 Makefile
-rw-r--r-- 1 certik certik   755 Nov  4 12:43 README.md
-rw-r--r-- 1 certik certik  1509 Nov  6 15:44 cmake_install.cmake
-rwxr-xr-x 1 certik certik 29624 Nov  6 15:44 minixonsh
drwxr-xr-x 2 certik certik  4096 Nov  6 15:42 src
-rw-r--r-- 1 certik certik    19 Nov  6 15:43 test1.xsh
CMakeCache.txt  CTestTestfile.cmake  README.md            src
CMakeFiles      LICENSE              cmake_install.cmake  test1.xsh
CMakeLists.txt  Makefile             minixonsh
OK

real	0m0.253s
user	0m0.185s
sys	0m0.078s
```
Bash:
```
$ time bash test1.xsh 
total 88
-rw-r--r-- 1 certik certik 12541 Nov  6 15:44 CMakeCache.txt
drwxr-xr-x 5 certik certik  4096 Nov  6 15:44 CMakeFiles
-rw-r--r-- 1 certik certik  1509 Nov  6 15:44 cmake_install.cmake
-rw-r--r-- 1 certik certik  1254 Nov  4 12:43 CMakeLists.txt
-rw-r--r-- 1 certik certik   269 Nov  6 15:44 CTestTestfile.cmake
-rw-r--r-- 1 certik certik  1513 Nov  4 12:43 LICENSE
-rw-r--r-- 1 certik certik  5136 Nov  6 15:44 Makefile
-rwxr-xr-x 1 certik certik 29624 Nov  6 15:44 minixonsh
-rw-r--r-- 1 certik certik   755 Nov  4 12:43 README.md
drwxr-xr-x 2 certik certik  4096 Nov  6 15:42 src
-rw-r--r-- 1 certik certik    19 Nov  6 15:43 test1.xsh
CMakeCache.txt	     CMakeLists.txt	  Makefile   src
CMakeFiles	     CTestTestfile.cmake  minixonsh  test1.xsh
cmake_install.cmake  LICENSE		  README.md
OK

real	0m0.034s
user	0m0.022s
sys	0m0.012s
```
Minixonsh:
```
$ time ./minixonsh test1.xsh 
+ /bin/ls -l
total 88
-rw-r--r-- 1 certik certik 12541 Nov  6 15:44 CMakeCache.txt
drwxr-xr-x 5 certik certik  4096 Nov  6 15:44 CMakeFiles
-rw-r--r-- 1 certik certik  1509 Nov  6 15:44 cmake_install.cmake
-rw-r--r-- 1 certik certik  1254 Nov  4 12:43 CMakeLists.txt
-rw-r--r-- 1 certik certik   269 Nov  6 15:44 CTestTestfile.cmake
-rw-r--r-- 1 certik certik  1513 Nov  4 12:43 LICENSE
-rw-r--r-- 1 certik certik  5136 Nov  6 15:44 Makefile
-rwxr-xr-x 1 certik certik 29624 Nov  6 15:44 minixonsh
-rw-r--r-- 1 certik certik   755 Nov  4 12:43 README.md
drwxr-xr-x 2 certik certik  4096 Nov  6 15:42 src
-rw-r--r-- 1 certik certik    19 Nov  6 15:43 test1.xsh
+ /bin/ls
CMakeCache.txt	     CMakeLists.txt	  Makefile   src
CMakeFiles	     CTestTestfile.cmake  minixonsh  test1.xsh
cmake_install.cmake  LICENSE		  README.md
+ /bin/echo "OK"
"OK"

real	0m0.010s
user	0m0.007s
sys	0m0.003s
```

Summary:

Xonsh: 253ms (7.4x slower than Bash)
Bash: 34ms
Minixonsh: 10ms (3.4x faster than Bash) :rocket: 


So the 3.4x faster than Bash gives us enough cushion to implement the full parser and all the bells & whistles that we want, and keep the speed hopefully even faster than Bash.